### PR TITLE
jsonschema

### DIFF
--- a/dataclass_factory/common.py
+++ b/dataclass_factory/common.py
@@ -11,6 +11,12 @@ class AbstractFactory:
     def serializer(self, class_: Type):
         raise NotImplementedError
 
+    def json_schema(self, class_: Type):
+        raise NotImplementedError
+
+    def json_schema_ref_name(self, class_: Type):
+        raise NotImplementedError
+
 
 Serializer = Callable[[T], Any]
 SerializerGetter = Callable[

--- a/dataclass_factory/factory.py
+++ b/dataclass_factory/factory.py
@@ -2,12 +2,12 @@ from copy import copy
 from typing import Dict, Type, Any, Optional, TypeVar
 
 from .common import Serializer, Parser, AbstractFactory
+from .jsonschema import create_schema
+from .naming import NameStyle
 from .parsers import create_parser, get_lazy_parser
 from .schema import Schema, merge_schema, Unknown
 from .serializers import create_serializer, get_lazy_serializer
 from .type_detection import is_generic_concrete
-from .naming import NameStyle
-from .jsonschema import get_ref_only, create_schema
 
 DEFAULT_SCHEMA = Schema[Any](
     trim_trailing_underscore=True,
@@ -25,12 +25,15 @@ class StackedFactory(AbstractFactory):
         self.stack = []
         self.factory = factory
 
-    def jsonschema(self, class_: Type):
+    def json_schema_ref_name(self, class_: Type):
+        return self.factory._json_schema_ref_name_with_stack(class_, self)
+
+    def json_schema(self, class_: Type):
         if class_ in self.stack:
-            return get_ref_only(class_)
+            return
         self.stack.append(class_)
         try:
-            return self.factory._jsonschema_with_stack(class_, self)
+            return self.factory._json_schema_with_stack(class_, self)
         finally:
             self.stack.pop()
 
@@ -71,6 +74,8 @@ class Factory(AbstractFactory):
                 type_: merge_schema(schema, self.default_schema)
                 for type_, schema in schemas.items()
             })
+        self.json_schemas: Dict[str, Dict] = {}
+        self.json_schema_names: Dict[str, Type] = {}
 
     def schema(self, class_: Type[T]) -> Schema[T]:
         if is_generic_concrete(class_):
@@ -106,12 +111,48 @@ class Factory(AbstractFactory):
             schema.parser = create_parser(stacked_factory, schema, self.debug_path, class_)
         return schema.parser
 
-    def jsonschema(self, class_: Type[T]) -> Parser[T]:
-        return self._jsonschema_with_stack(class_, StackedFactory(self))
+    def json_schema_ref_name(self, class_: Type[T]):
+        return self._json_schema_ref_name_with_stack(class_, StackedFactory(self))
 
-    def _jsonschema_with_stack(self, class_: Type[T], stacked_factory: StackedFactory) -> Parser[T]:
+    def _json_schema_ref_name_with_stack(self, class_: Type[T], stacked_factory: StackedFactory):
         schema = self.schema(class_)
-        return create_schema(stacked_factory, schema, class_)
+        if schema.name is not None:
+            if schema.name not in self.json_schema_names:
+                return schema.name
+            if self.json_schema_names[schema.name] != class_:
+                raise ValueError(f"Already found type with name `{schema.name}`: "
+                                 f"{self.json_schema_names[schema.name]}. "
+                                 f"Please, specify another name for {class_}")
+            return schema.name
+        name = getattr(class_, "__qualname__", "") or getattr(class_, "__name__", "") or str(class_)
+        if name in self.json_schema_names:
+            raise ValueError(f"Already found type with name `{name}`: "
+                             f"{self.json_schema_names[name]}. "
+                             f"Please, specify another name for {class_} "
+                             f"in schema or rename class itself")
+        schema.name = name
+        stacked_factory.json_schema(class_)
+        return name
+
+    def json_schema(self, class_: Type[T]) -> Parser[T]:
+        return self._json_schema_with_stack(class_, StackedFactory(self))
+
+    def json_schema_definitions(self) -> Parser[T]:
+        return {
+            "definitions": {
+                k: v
+                for k, v in self.json_schemas.items()
+            }
+        }
+
+    def _json_schema_with_stack(self, class_: Type[T], stacked_factory: StackedFactory) -> Parser[T]:
+        schema = self.schema(class_)
+        name = self._json_schema_ref_name_with_stack(class_, stacked_factory)
+        if name in self.json_schemas:
+            return self.json_schemas[name]
+        json_schema = create_schema(stacked_factory, schema, class_)
+        self.json_schemas[name] = json_schema
+        return json_schema
 
     def serializer(self, class_: Type[T]) -> Serializer[T]:
         return self._serializer_with_stack(class_, StackedFactory(self))

--- a/dataclass_factory/factory.py
+++ b/dataclass_factory/factory.py
@@ -136,10 +136,10 @@ class Factory(AbstractFactory):
         stacked_factory.json_schema(class_)
         return name
 
-    def json_schema(self, class_: Type[T]) -> Parser[T]:
+    def json_schema(self, class_: Type[T]) -> Dict[str, Any]:
         return self._json_schema_with_stack(class_, StackedFactory(self))
 
-    def json_schema_definitions(self) -> Parser[T]:
+    def json_schema_definitions(self) -> Dict[str, Any]:
         return {
             "definitions": {
                 k: v
@@ -147,7 +147,7 @@ class Factory(AbstractFactory):
             }
         }
 
-    def _json_schema_with_stack(self, class_: Type[T], stacked_factory: StackedFactory) -> Parser[T]:
+    def _json_schema_with_stack(self, class_: Type[T], stacked_factory: StackedFactory) -> Dict[str, Any]:
         schema = self.schema(class_)
         name = self._json_schema_ref_name_with_stack(class_, stacked_factory)
         if name in self.json_schemas:

--- a/dataclass_factory/fields.py
+++ b/dataclass_factory/fields.py
@@ -27,18 +27,14 @@ class FieldInfo(BaseFieldInfo):
 
 # defaults
 
-def get_dataclass_default(field: Field, omit_default: Optional[bool]) -> Any:
-    if not omit_default:
-        return MISSING
+def get_dataclass_default(field: Field) -> Any:
     # type ignore because of https://github.com/python/mypy/issues/6910
     if field.default_factory != MISSING:  # type: ignore
         return field.default_factory()  # type: ignore
     return field.default
 
 
-def get_func_default(paramter: inspect.Parameter, omit_default: Optional[bool]) -> Any:
-    if not omit_default:
-        return MISSING
+def get_func_default(paramter: inspect.Parameter) -> Any:
     # type ignore because of https://github.com/python/mypy/issues/6910
     if paramter.default is inspect.Parameter.empty:
         return MISSING
@@ -56,7 +52,7 @@ def all_dataclass_fields(cls, omit_default: Optional[bool], filter_func: FilterF
         all_fields = fields(cls)
     hints = resolve_hints(cls)
     return [
-        BaseFieldInfo(field_name=f.name, type=hints[f.name], default=get_dataclass_default(f, omit_default))
+        BaseFieldInfo(field_name=f.name, type=hints[f.name], default=get_dataclass_default(f))
         for f in all_fields
         if not filter_func or filter_func(f.name) and f.init
     ]
@@ -66,7 +62,7 @@ def all_class_fields(cls, omit_default: Optional[bool], filter_func: FilterFunc 
     all_fields = inspect.signature(cls.__init__).parameters
     hints = resolve_init_hints(cls)
     return [
-        BaseFieldInfo(field_name=f.name, type=hints.get(f.name, Any), default=get_func_default(f, omit_default))
+        BaseFieldInfo(field_name=f.name, type=hints.get(f.name, Any), default=get_func_default(f))
         for f in all_fields.values()
         if not filter_func or filter_func(f.name)
     ]

--- a/dataclass_factory/jsonschema.py
+++ b/dataclass_factory/jsonschema.py
@@ -1,12 +1,12 @@
 import decimal
-from typing import Dict, Optional
+from typing import Dict, Optional, Any
 from typing import (
     Type
 )
 
 from dataclasses import is_dataclass, MISSING
 
-from .common import AbstractFactory, T
+from .common import AbstractFactory
 from .fields import get_dataclass_fields, get_typeddict_fields
 from .schema import Schema, Unknown
 from .type_detection import (
@@ -40,19 +40,19 @@ def get_type(cls) -> Optional[str]:
     elif is_tuple(cls) or is_collection(cls):
         return "array"
     elif is_union(cls) or is_enum(cls):
-        return
+        return None
     return "object"
 
 
-def type_or_ref(class_, factory: AbstractFactory):
+def type_or_ref(class_, factory: AbstractFactory) -> Dict[str, Any]:
     if need_ref(class_):
         ref = factory.json_schema_ref_name(class_)
         return {"$ref": f"#/definitions/{ref}"}
     return {"type": get_type(class_)}
 
 
-def unknown(factory: AbstractFactory, schema: Schema, cls: Type[T]) -> Dict:
-    res = {}
+def unknown(factory: AbstractFactory, schema: Schema, cls: Type) -> Dict[str, Any]:
+    res: Dict[str, Any] = {}
     if schema.unknown == Unknown.FORBID:
         res["additionalProperties"] = False
     elif schema.unknown in (Unknown.SKIP, Unknown.STORE):
@@ -62,8 +62,8 @@ def unknown(factory: AbstractFactory, schema: Schema, cls: Type[T]) -> Dict:
     return res
 
 
-def typed_dict_schema(factory: AbstractFactory, schema: Schema, cls: Type[T]):
-    res = {}
+def typed_dict_schema(factory: AbstractFactory, schema: Schema, cls: Type) -> Dict[str, Any]:
+    res: Dict[str, Any] = {}
     fields = get_typeddict_fields(schema, cls)
     if schema.name_mapping and any(isinstance(key, tuple) for key in schema.name_mapping.values()):
         raise NotImplementedError("Schema flattening is not yet supported")
@@ -79,8 +79,9 @@ def typed_dict_schema(factory: AbstractFactory, schema: Schema, cls: Type[T]):
         ]
     return res
 
-def dataclass_schema(factory: AbstractFactory, schema: Schema, cls: Type[T]):
-    res = {}
+
+def dataclass_schema(factory: AbstractFactory, schema: Schema, cls: Type) -> Dict[str, Any]:
+    res: Dict[str, Any] = {}
     fields = get_dataclass_fields(schema, cls)
     if schema.name_mapping and any(isinstance(key, tuple) for key in schema.name_mapping.values()):
         raise NotImplementedError("Schema flattening is not yet supported")
@@ -96,8 +97,8 @@ def dataclass_schema(factory: AbstractFactory, schema: Schema, cls: Type[T]):
     return res
 
 
-def create_schema(factory: AbstractFactory, schema: Schema, cls: Type[T]) -> Dict:
-    res = {}
+def create_schema(factory: AbstractFactory, schema: Schema, cls: Type) -> Dict[str, Any]:
+    res: Dict[str, Any] = {}
     if schema.name:
         res["title"] = schema.name
     if schema.description:

--- a/dataclass_factory/jsonschema.py
+++ b/dataclass_factory/jsonschema.py
@@ -90,7 +90,7 @@ def dataclass_schema(factory: AbstractFactory, schema: Schema, cls: Type) -> Dic
     for f in fields:
         res["properties"][f.data_name] = type_or_ref(f.type, factory)
         if f.default is not MISSING and f.type:
-            res["properties"][f.data_name]["default"] = f.default
+            res["properties"][f.data_name]["default"] = factory.serializer(f.type)(f.default)
     res["required"] = [
         f.data_name for f in fields if f.default is MISSING
     ]
@@ -98,12 +98,14 @@ def dataclass_schema(factory: AbstractFactory, schema: Schema, cls: Type) -> Dic
 
 
 def create_schema(factory: AbstractFactory, schema: Schema, cls: Type) -> Dict[str, Any]:
+    if cls is Any:
+        return {}
+
     res: Dict[str, Any] = {}
     if schema.name:
         res["title"] = schema.name
     if schema.description:
         res["description"] = schema.description
-
     type = get_type(cls)
     if type:
         res["type"] = type

--- a/dataclass_factory/jsonschema.py
+++ b/dataclass_factory/jsonschema.py
@@ -1,0 +1,116 @@
+import decimal
+from typing import Dict, Optional
+from typing import (
+    Type
+)
+
+from dataclasses import is_dataclass, MISSING
+
+from .fields import get_dataclass_fields, get_typeddict_fields
+from .type_detection import (
+    is_tuple, is_collection, hasargs, is_none, is_union, is_dict, is_enum,
+    is_typeddict,
+    is_generic_concrete,
+)
+
+definitions = {}
+definitions_rev = {}
+schemas = {}
+
+
+def get_ref(cls, factory):
+    schemas[cls] = factory.jsonschema(cls)
+    return get_ref_only(cls)
+
+
+def get_ref_only(cls):
+    if cls in (int, str, bool, float, decimal.Decimal):
+        return
+    if is_none(cls):
+        return
+    if cls in definitions:
+        return definitions[cls]
+    name = getattr(cls, "__qualname__", "") or getattr(cls, "__name__", "") or str(cls)
+    if name in definitions_rev:
+        raise ValueError(
+            f"Already found type with name `{name}`: {definitions_rev[name]}. Please, specify another name for {cls}")
+    definitions_rev[name] = cls
+    definitions[cls] = name
+    return name
+
+
+def get_type(cls) -> Optional[str]:
+    if is_none(cls):
+        return "null"
+    if cls in (int,):
+        return "integer"
+    elif cls in (float, decimal.Decimal):
+        return "number"
+    elif cls in (str,):
+        return "string"
+    elif cls in (bool,):
+        return "boolean"
+    elif is_dict(cls):
+        return "object"
+    elif is_tuple(cls) or is_collection(cls):
+        return "array"
+    elif is_union(cls) or is_enum(cls):
+        return
+    return "object"
+
+
+def type_or_ref(cls, factory):
+    ref = get_ref(cls, factory)
+    if ref:
+        return {"$ref": f"#/definitions/{ref}"}
+    return {"type": get_type(cls)}
+
+
+def create_schema(factory, schema, cls: Type) -> Dict:
+    # TODO fields flattening and unknown
+    if cls in schemas:
+        return schemas[cls]
+    res = {}
+    if hasattr(cls, "__name__"):
+        res["title"] = cls.__name__
+    type = get_type(cls)
+    if type:
+        res["type"] = type
+
+    if is_enum(cls):
+        res["enum"] = [x.value for x in cls]
+    elif is_dict(cls):
+        res["additionalProperties"] = type_or_ref(cls.__args__[1], factory)
+    elif is_tuple(cls):
+        if not hasargs(cls):
+            pass
+        elif len(cls.__args__) == 2 and cls.__args__[1] is Ellipsis:
+            res["items"] = type_or_ref(cls.__args__[0], factory)
+        else:
+            res["items"] = [type_or_ref(x, factory) for x in cls.__args__]
+    elif is_typeddict(cls) or (is_generic_concrete(cls) and is_typeddict(cls.__origin__)):
+        fields = get_typeddict_fields(schema, cls)
+        res["properties"] = {}
+        for f in fields:
+            res["properties"][f.data_name] = type_or_ref(f.type, factory)
+            if f.default is not MISSING:
+                res["properties"][f.data_name]["default"] = f.default
+        if cls.__total__:
+            res["required"] = [
+                f.data_name for f in fields
+            ]
+    elif is_collection(cls):
+        res["items"] = type_or_ref(cls.__args__[0], factory)
+    elif is_union(cls):
+        res["anyOf"] = [type_or_ref(x, factory) for x in cls.__args__]
+    elif is_dataclass(cls) or (is_generic_concrete(cls) and is_dataclass(cls.__origin__)):
+        fields = get_dataclass_fields(schema, cls)
+        res["properties"] = {}
+        for f in fields:
+            res["properties"][f.data_name] = type_or_ref(f.type, factory)
+            if f.default is not MISSING:
+                res["properties"][f.data_name]["default"] = f.default
+        res["required"] = [
+            f.data_name for f in fields if f.default is MISSING
+        ]
+    return res

--- a/dataclass_factory/schema.py
+++ b/dataclass_factory/schema.py
@@ -44,6 +44,8 @@ class Schema(Generic[T]):
 
             omit_default: Optional[bool] = None,
             unknown: RuleForUnknown = None,
+            name: Optional[str] = None,
+            description: Optional[str] = None,
     ):
 
         if only is not None or not hasattr(self, "only"):
@@ -86,6 +88,11 @@ class Schema(Generic[T]):
         if unknown is not None or not hasattr(self, "unknown"):
             self.unknown = unknown
 
+        if name is not None or not hasattr(self, "name"):
+            self.name = name
+        if description is not None or not hasattr(self, "description"):
+            self.description = description
+
 
 SCHEMA_FIELDS = [
     "only",
@@ -104,6 +111,8 @@ SCHEMA_FIELDS = [
     "pre_serialize",
     "post_serialize",
     "unknown",
+    "name",
+    "description",
 ]
 
 

--- a/dataclass_factory/serializers.py
+++ b/dataclass_factory/serializers.py
@@ -31,7 +31,7 @@ def get_complex_serializer(factory: AbstractFactory,
                            fields: Sequence[FieldInfo],
                            getter: Callable[[Any, Any], Any],
                            unknown: RuleForUnknown) -> Serializer[T]:
-    has_default = any(f.default != MISSING for f in fields)
+    has_default = schema.omit_default and any(f.default != MISSING for f in fields)
     field_info = tuple(
         (f.field_name, factory.serializer(f.type), f.data_name, f.default)
         for f in fields

--- a/docs/examples/jsonschema.py
+++ b/docs/examples/jsonschema.py
@@ -1,0 +1,25 @@
+import json
+from enum import Enum
+from typing import Dict, Union
+
+from dataclasses import dataclass, field
+
+from dataclass_factory import Factory, Schema
+
+
+class A(Enum):
+    X = "x"
+    Y = 1
+
+
+@dataclass
+class Data:
+    a: A
+    dict_: Dict[str, Union[int, float]]
+    dictw_: Dict[str, Union[int, float]] = field(default_factory=dict)
+    optional_num: int = 0
+
+
+factory = Factory(schemas={A: Schema(description="My super `A` class")})
+print(json.dumps(factory.json_schema(Data), indent=2))
+print(json.dumps(factory.json_schema_definitions(), indent=2))

--- a/docs/examples/jsonschema_defs.json
+++ b/docs/examples/jsonschema_defs.json
@@ -1,0 +1,55 @@
+{
+  "definitions": {
+    "A": {
+      "title": "A",
+      "description": "My super `A` class",
+      "enum": [
+        "x",
+        1
+      ]
+    },
+    "typing.Union[int, float]": {
+      "title": "typing.Union[int, float]",
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "number"
+        }
+      ]
+    },
+    "typing.Dict[str, typing.Union[int, float]]": {
+      "title": "typing.Dict[str, typing.Union[int, float]]",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/typing.Union[int, float]"
+      }
+    },
+    "Data": {
+      "title": "Data",
+      "type": "object",
+      "properties": {
+        "a": {
+          "$ref": "#/definitions/A"
+        },
+        "dict": {
+          "$ref": "#/definitions/typing.Dict[str, typing.Union[int, float]]"
+        },
+        "dictw": {
+          "$ref": "#/definitions/typing.Dict[str, typing.Union[int, float]]",
+          "default": {}
+        },
+        "optional_num": {
+          "type": "integer",
+          "default": 0
+        }
+      },
+      "additionalProperties": true,
+      "required": [
+        "a",
+        "dict"
+      ]
+    }
+  }
+}

--- a/docs/examples/jsonschema_res.json
+++ b/docs/examples/jsonschema_res.json
@@ -1,0 +1,25 @@
+{
+  "title": "Data",
+  "type": "object",
+  "properties": {
+    "a": {
+      "$ref": "#/definitions/A"
+    },
+    "dict": {
+      "$ref": "#/definitions/typing.Dict[str, typing.Union[int, float]]"
+    },
+    "dictw": {
+      "$ref": "#/definitions/typing.Dict[str, typing.Union[int, float]]",
+      "default": {}
+    },
+    "optional_num": {
+      "type": "integer",
+      "default": 0
+    }
+  },
+  "additionalProperties": true,
+  "required": [
+    "a",
+    "dict"
+  ]
+}

--- a/docs/extended.rst
+++ b/docs/extended.rst
@@ -213,9 +213,32 @@ In some case it is useful to subclass Schema instead of just creating instances 
 .. literalinclude:: examples/subclass.py
 
 .. note::
-    Factory creates a copy of schema for each type filling missed args.
+    In versions <2.9: Factory created a copy of schema for each type filling missed args.
     If you need to get access to some data in schema, get a working instance of schema with ``Factory.schema`` method
 
 .. note::
     Single schema instance can be used multiple time simultaneously because of multithreading or recursive structures.
     Be careful modifying data in schema
+
+
+Json-schema
+==========================
+
+You can generate json schema for your classes.
+
+Note that factory does it lazily and caches result. So if you need definitions for all your classes, create schema for each top-level class using ``json_schema`` method
+and then collect all definitions using ``json_schema_definitions``
+
+.. literalinclude:: examples/jsonschema.py
+
+Result of ``json_schema`` call is
+
+.. literalinclude:: examples/jsonschema_res.json
+
+Result of ``json_schema_definitions`` call is
+
+.. literalinclude:: examples/jsonschema_defs.json
+
+.. note::
+    Not all features of dataclass factory are suppoerted currently. You cannot generate json-schema if you use structure-flattening, additional parsing of unknown fields or init-based parsing.
+    Also, if you have custom parsers or pre-parse step, schema might be incorrect.


### PR DESCRIPTION
TODO: 
- [ ] Generate schema with required only definitions for certain class
- [ ] Field flatten
- [ ] Unknown fields and additionalProperties
- [x] Any type

```python

class A(Enum):
    X = "x"
    Y = 1


@dataclass
class Data:
    a: A
    dict_: Dict[str, Union[int, float]]
    optional_num: int = 0


factory = Factory(default_schema=Schema(omit_default=True), schemas={A: Schema(description="My super `A` class")})
factory.json_schema(Data)  # warm up

print(json.dumps(factory.json_schema_definitions(), indent=2))
```

Result is: 
```json
{
  "definitions": {
    "A": {
      "title": "A",
      "description": "My super `A` class",
      "enum": [
        "x",
        1
      ]
    },
    "typing.Union[int, float]": {
      "title": "typing.Union[int, float]",
      "anyOf": [
        {
          "type": "integer"
        },
        {
          "type": "number"
        }
      ]
    },
    "typing.Dict[str, typing.Union[int, float]]": {
      "title": "typing.Dict[str, typing.Union[int, float]]",
      "type": "object",
      "additionalProperties": {
        "$ref": "#/definitions/typing.Union[int, float]"
      }
    },
    "Data": {
      "title": "Data",
      "type": "object",
      "properties": {
        "a": {
          "$ref": "#/definitions/A"
        },
        "dict": {
          "$ref": "#/definitions/typing.Dict[str, typing.Union[int, float]]"
        },
        "optional_num": {
          "type": "integer",
          "default": 0
        }
      },
      "required": [
        "a",
        "dict"
      ]
    }
  }
}
```

closes #102 