### PR TITLE
Support NewType

### DIFF
--- a/dataclass_factory/parsers.py
+++ b/dataclass_factory/parsers.py
@@ -331,6 +331,8 @@ def create_parser_impl(factory, schema: Schema, debug_path: bool, cls: Type) -> 
         return cls
     if cls in (decimal.Decimal,):
         return decimal_parse
+    if is_newtype(cls):
+        return create_parser_impl(factory, schema, debug_path, cls.__supertype__)
     if is_enum(cls):
         return cls
     if is_tuple(cls):
@@ -389,8 +391,6 @@ def create_parser_impl(factory, schema: Schema, debug_path: bool, cls: Type) -> 
             pre_validators=schema.pre_validators,
             post_validators=schema.post_validators,
         )
-    if is_newtype(cls):
-        return create_parser_impl(factory, schema, debug_path, cls.__supertype__)
     try:
         return get_complex_parser(
             class_=cls,

--- a/dataclass_factory/parsers.py
+++ b/dataclass_factory/parsers.py
@@ -13,7 +13,7 @@ from .path_utils import CleanKey, CleanPath
 from .schema import RuleForUnknown, Schema, Unknown
 from .type_detection import (
     args_unspecified, hasargs, is_any, is_collection, is_dict,
-    is_enum, is_generic_concrete, is_literal, is_literal36,
+    is_enum, is_generic_concrete, is_literal, is_literal36, is_newtype,
     is_none, is_optional, is_tuple, is_typeddict, is_union,
 )
 from .validators import combine_parser_validators
@@ -389,6 +389,8 @@ def create_parser_impl(factory, schema: Schema, debug_path: bool, cls: Type) -> 
             pre_validators=schema.pre_validators,
             post_validators=schema.post_validators,
         )
+    if is_newtype(cls):
+        return create_parser_impl(factory, schema, debug_path, cls.__supertype__)
     try:
         return get_complex_parser(
             class_=cls,

--- a/dataclass_factory/serializers.py
+++ b/dataclass_factory/serializers.py
@@ -8,7 +8,7 @@ from .fields import FieldInfo, get_dataclass_fields, get_typeddict_fields
 from .path_utils import CleanKey, CleanPath, init_structure
 from .schema import RuleForUnknown, Schema, Unknown
 from .type_detection import (
-    hasargs, is_any, is_collection, is_dict, is_enum, is_generic_concrete,
+    hasargs, is_any, is_collection, is_dict, is_enum, is_generic_concrete, is_newtype,
     is_optional, is_tuple, is_type_var, is_typeddict, is_union,
 )
 
@@ -207,5 +207,7 @@ def create_serializer_impl(factory, schema: Schema, debug_path: bool, class_: Ty
     if is_collection(class_):
         item_serializer = get_lazy_serializer(factory)
         return get_collection_serializer(item_serializer)
+    if is_newtype(class_):
+        return create_serializer_impl(factory, schema, debug_path, class_.__supertype__)
     else:
         return get_vars_serializer(factory)

--- a/dataclass_factory/serializers.py
+++ b/dataclass_factory/serializers.py
@@ -153,6 +153,8 @@ def create_serializer(factory, schema: Schema, debug_path: bool, class_: Type) -
 def create_serializer_impl(factory, schema: Schema, debug_path: bool, class_: Type) -> Serializer:  # noqa C901,CCR001
     if class_ in (str, bytearray, bytes, int, float, complex, bool):
         return stub_serializer
+    if is_newtype(class_):
+        return create_serializer_impl(factory, schema, debug_path, class_.__supertype__)
     if is_type_var(class_):
         return get_lazy_serializer(factory)
     if is_dataclass(class_) or (is_generic_concrete(class_) and is_dataclass(class_.__origin__)):
@@ -207,7 +209,5 @@ def create_serializer_impl(factory, schema: Schema, debug_path: bool, class_: Ty
     if is_collection(class_):
         item_serializer = get_lazy_serializer(factory)
         return get_collection_serializer(item_serializer)
-    if is_newtype(class_):
-        return create_serializer_impl(factory, schema, debug_path, class_.__supertype__)
     else:
         return get_vars_serializer(factory)

--- a/dataclass_factory/type_detection.py
+++ b/dataclass_factory/type_detection.py
@@ -77,6 +77,10 @@ def issubclass_safe(cls, classinfo) -> bool:
         return result
 
 
+def is_newtype(type_) -> bool:
+    return hasattr(type_, "__supertype__") and hasattr(type_, "__name__")
+
+
 def is_tuple(type_) -> bool:
     try:
         # __origin__ exists in 3.7 on user defined generics

--- a/tests/test_newtype.py
+++ b/tests/test_newtype.py
@@ -1,0 +1,48 @@
+from dataclasses import dataclass
+from typing import List, NewType
+from unittest import TestCase
+
+from dataclass_factory import Factory
+
+
+Id = NewType("Id", int)
+
+
+@dataclass
+class Duck:
+    id: Id
+    ducklings: List["Duck"]
+
+
+class TestNewtype(TestCase):
+    def test_serialize(self):
+        factory = Factory()
+        duck = Duck(
+            Id(0),
+            [Duck(Id(1), []), Duck(Id(2), [])]
+        )
+        expected = {
+            'id': 0,
+            'ducklings': [
+                {'id': 1, 'ducklings': []},
+                {'id': 2, 'ducklings': []},
+            ],
+        }
+        serialized = factory.dump(duck)
+        self.assertEqual(expected, serialized)
+
+    def test_parse(self):
+        factory = Factory()
+        serialized = {
+            'id': 0,
+            'ducklings': [
+                {'id': 1, 'ducklings': []},
+                {'id': 2, 'ducklings': []},
+            ]
+        }
+        expected = Duck(
+            Id(0),
+            [Duck(Id(1), []), Duck(Id(2), [])]
+        )
+        parsed = factory.load(serialized, Duck)
+        self.assertEqual(expected, parsed)


### PR DESCRIPTION
`NewType` is a tool primarily for documentation and typecheckers. It allows you to attach a named tag to a type without changing its runtime representation.
```py
Id = NewType("Id", int)

my_id: Id = 42  # typechecker complains
my_id: Id = Id(42)  # typechecker is happy

# but at runtime, `my_id` is still an `int`
assert type(my_id) is int
```
