### PR TITLE
Implement re.Pattern serializing/deserializing

### DIFF
--- a/dataclass_factory/parsers.py
+++ b/dataclass_factory/parsers.py
@@ -6,6 +6,7 @@ from typing import (
     List, Optional, Sequence, Set, Tuple, Type, Union, Iterable,
     MutableSequence, MutableSet, Reversible,
 )
+from re import Pattern, compile as regex_compile
 
 from .common import AbstractFactory, Parser, T
 from .exceptions import InvalidFieldError, UnionParseError, UnknownFieldsError
@@ -308,7 +309,6 @@ def get_literal_parser(factory, values: Sequence[Any]) -> Parser:
 
     return literal_parser
 
-
 def get_lazy_parser(factory, class_: Type) -> Parser:
     def lazy_parser(data):
         return factory.load(data, class_)
@@ -345,6 +345,8 @@ def create_parser_impl(factory, schema: Schema, debug_path: bool, cls: Type) -> 
         return get_literal_parser(factory, cls.__values__)
     if is_optional(cls):
         return get_optional_parser(factory.parser(cls.__args__[0]))
+    if cls is Pattern:
+        return regex_compile
     if cls in (str, bytearray, bytes):
         return get_parser_with_check(cls)
     if cls in (int, float, complex, bool):

--- a/dataclass_factory/serializers.py
+++ b/dataclass_factory/serializers.py
@@ -2,6 +2,7 @@ from dataclasses import is_dataclass, MISSING
 from marshal import dumps, loads
 from operator import attrgetter, getitem
 from typing import Any, Callable, Dict, List, Optional, Sequence, Type, Union
+from re import Pattern, compile as regex_compile
 
 from .common import AbstractFactory, K, Serializer, T
 from .fields import (
@@ -120,6 +121,8 @@ def get_vars_serializer(factory) -> Serializer:
 def stub_serializer(data: T) -> T:
     return data
 
+def regex_serializer(data: Pattern) -> str:
+    return data.pattern
 
 def get_dict_serializer(
     key_serializer: Serializer[K], serializer: Serializer[T]
@@ -168,6 +171,8 @@ def create_serializer_impl(factory, schema: Schema, debug_path: bool,
     class_ = fix_generic_alias(class_)
     if class_ in (str, bytearray, bytes, int, float, complex, bool):
         return stub_serializer
+    if class_ is Pattern:
+        return regex_serializer
     if is_literal(class_) or is_literal36(class_) or is_none(class_):
         return stub_serializer
     if is_newtype(class_):

--- a/tests/test_regex_pattern.py
+++ b/tests/test_regex_pattern.py
@@ -1,0 +1,19 @@
+from dataclasses import dataclass
+from unittest import TestCase
+from re import compile, Pattern
+
+from dataclass_factory import Factory
+
+
+@dataclass
+class RegexPattern:
+    pattern: Pattern
+
+
+class TestFactory(TestCase):
+    def test_pattern(self):
+        factory = Factory()
+        data_object = RegexPattern(pattern=compile(r"testcase"))
+        data = {"pattern": "testcase"}
+
+        self.assertEqual(factory.load(data, RegexPattern), data_object)

--- a/tests/test_serializer_base.py
+++ b/tests/test_serializer_base.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Dict, List, Optional
+from re import Pattern, compile
 import unittest
 
 from dataclass_factory import Factory
@@ -17,6 +18,9 @@ class D:
     b: int = field(init=False, default=1)
     c: str = "def_value"
 
+@dataclass
+class RegexPattern:
+    pattern: Pattern
 
 @dataclass
 class ListD:
@@ -33,6 +37,14 @@ class DictD:
 class TestSerializer(unittest.TestCase):
     def setUp(self) -> None:
         self.factory = Factory()
+
+    def test_regex_pattern(self):
+        serializer = self.factory.serializer(RegexPattern)
+        regex_pattern = RegexPattern(compile(r'testcase'))
+        self.assertEqual(
+            serializer(regex_pattern),
+            {"pattern": "testcase"}
+        )
 
     def test_plain(self):
         serializer = self.factory.serializer(D)


### PR DESCRIPTION
Implement regex serializing/deserializing. E.g.

```py3
@dataclass
class SomePattern:
    prefix: Pattern

factory = Factory()
deserialized = SomePattern(prefix=compile(r'prefixed'))

print(factory.load({"prefix": "prefixed"}, SomePattern))  # SomePattern(prefix=re.compile('prefixed'))
print(factory.dump(deserialized))  # {"prefix": "prefixed"}
```